### PR TITLE
Fix: remove redundant plt.figure() to prevent memory leak

### DIFF
--- a/tools/maptr/vis_pred.py
+++ b/tools/maptr/vis_pred.py
@@ -356,10 +356,6 @@ def main():
         pts_3d = result_dic['pts_3d']
         keep = scores_3d > args.score_thresh
 
-        plt.figure(figsize=(2, 4))
-        plt.xlim(pc_range[0], pc_range[3])
-        plt.ylim(pc_range[1], pc_range[4])
-        plt.axis('off')
         for pred_score_3d, pred_bbox_3d, pred_label_3d, pred_pts_3d in zip(scores_3d[keep], boxes_3d[keep],labels_3d[keep], pts_3d[keep]):
 
             pred_pts_3d = pred_pts_3d.numpy()


### PR DESCRIPTION
This pull request removes a redundant call to plt.figure() in vis_pred.py.

The duplicated plt.figure() at line 359 was unnecessary, as a figure was already created at line 345 and properly closed later. Keeping both leads to excessive figure creation during large-scale visualization, eventually causing memory exhaustion and killing the process.

Removing the extra call helps prevent memory leaks and allows the script to run to completion when visualizing large datasets.

Thank you for your great work on this project!