### PR TITLE
fixed bev_pool cuda .cu wrong cur_geom_feats address in file bev_pool_cuda.cu

### DIFF
--- a/mmdetection3d/mmdet3d/ops/bev_pool/src/bev_pool_cuda.cu
+++ b/mmdetection3d/mmdet3d/ops/bev_pool/src/bev_pool_cuda.cu
@@ -29,7 +29,7 @@ __global__ void bev_pool_kernel(int b, int d, int h, int w, int n, int c, int n_
   if (index >= n_intervals) return;
   int interval_start = interval_starts[index];
   int interval_length = interval_lengths[index];
-  const int* cur_geom_feats = geom_feats + interval_start * 4;
+  const int* cur_geom_feats = geom_feats + (interval_start + interval_length - 1) * 4;
   const float* cur_x = x + interval_start * c + cur_c;
   float* cur_out = out + cur_geom_feats[3] * d * h * w * c + 
     cur_geom_feats[2] * h * w * c + cur_geom_feats[0] * w * c + 
@@ -71,7 +71,7 @@ __global__ void bev_pool_grad_kernel(int b, int d, int h, int w, int n, int c, i
   int interval_start = interval_starts[index];
   int interval_length = interval_lengths[index];
   
-  const int* cur_geom_feats = geom_feats + interval_start * 4;
+  const int* cur_geom_feats = geom_feats + (interval_start + interval_length - 1) * 4;
   float* cur_x_grad = x_grad + interval_start * c + cur_c;
   
   const float* cur_out_grad = out_grad + cur_geom_feats[3] * d * h * w * c + 


### PR DESCRIPTION
## Contribution
I fix a problem with wrong cur_geom_feats address in file of bev_pool_cuda.cu.

## Problem
The result is different between the output of function QuickCumsumCuda and the output of function QuickCumsum in file [bev_pool.py](https://github.com/hustvl/MapTR/blob/main/mmdetection3d/mmdet3d/ops/bev_pool/bev_pool.py) or [bev_pool.py](https://github.com/open-mmlab/mmdetection3d/blob/fe25f7a51d36e3702f961e198894580d83c4387b/projects/BEVFusion/bevfusion/ops/bev_pool/bev_pool.py) and [another repo](https://github.com/weiyangdaren/Fisheye3DOD/blob/main/models/bevdet/ops/bev_pool/bev_pool.py).

the reason is the wrong implement of file [bev_pool_cuda.cu](https://github.com/hustvl/MapTR/blob/main/mmdetection3d/mmdet3d/ops/bev_pool/src/bev_pool_cuda.cu) and [another repo](https://github.com/weiyangdaren/Fisheye3DOD/blob/main/models/bevdet/ops/bev_pool/src/bev_pool_cuda.cu)

## Reproduce
To reproduce the wrong different result, you can follow the instruction of file README.md [https://github.com/ZouJiu1/bevPool/blob/master/README.md](https://github.com/ZouJiu1/bevPool/blob/master/README.md)

### step 1 
reproduce the problem

download the file [bev_pool_cuda.cu](https://github.com/weiyangdaren/Fisheye3DOD/tree/main/models/bevdet/ops/bev_pool/src)

>mv bev_pool/src/bev_pool_cuda.cu bev_pool/src/bev_pool_cuda_tmp.cu

```Bash []
git clone https://github.com/ZouJiu1/bevPool.git

cd bevPool

pip install -e .

cd bev_pool

python3 bev_pool.py
```

by checking or debuging or printing the variables like error, errorMean, www, tmp, tmp2 in file bev_pool.py, you can reproduce the problem

### step 2
fix the problem

>mv bev_pool/src/bev_pool_cuda_tmp.cu bev_pool/src/bev_pool_cuda.cu

```Bash []
cd bevPool

pip install -e .

cd bev_pool

python3 bev_pool.py
```
by checking variables  in file bev_pool.py, you will find the problem is fixed.

## Environment: 
Ubuntu22.04
Python 3.10.12 
torch 2.2.2+cu118
torchvision 0.17.2+cu118
mmcv 2.1.0
mmengine 0.10.7
mmdet 3.3.0
mmdet3d 1.4.0
cuda 11.8
cudnn 8.9.7
gcc g++ 11.4.0

## Motivation

fix some problem.

## Modification

fixed wrong cur_geom_feats address in file of bev_pool_cuda.cu

**others:**

[https://github.com/hustvl/MapTR/pull/212](https://github.com/hustvl/MapTR/pull/212)
[https://github.com/autowarefoundation/autoware_universe/pull/12491](https://github.com/autowarefoundation/autoware_universe/pull/12491)
[https://github.com/open-mmlab/mmdetection3d/pull/3143](https://github.com/open-mmlab/mmdetection3d/pull/3143)
[https://github.com/weiyangdaren/Fisheye3DOD/pull/4](https://github.com/weiyangdaren/Fisheye3DOD/pull/4)
[https://github.com/hustvl/VMA/pull/21](https://github.com/hustvl/VMA/pull/21)